### PR TITLE
fix: add accessible labels to form fields

### DIFF
--- a/src/components/Form.jsx
+++ b/src/components/Form.jsx
@@ -13,8 +13,15 @@ const Form = ({ fields = [], buttonLabel, withBackground = true }) => {
               key={index}
               className={`${field.fullWidth ? "md:col-span-2" : ""}`}
             >
+              <label
+                htmlFor={field.name}
+                className="block text-sm text-purple-text mb-1 text-left"
+              >
+                {field.label || field.placeholder}
+              </label>
               {field.type === "textarea" ? (
                 <textarea
+                  id={field.name}
                   name={field.name}
                   rows={field.rows || 2}
                   placeholder={field.placeholder || field.label}
@@ -22,6 +29,7 @@ const Form = ({ fields = [], buttonLabel, withBackground = true }) => {
                 ></textarea>
               ) : (
                 <input
+                  id={field.name}
                   type={field.type || "text"}
                   name={field.name}
                   placeholder={field.placeholder || field.label}


### PR DESCRIPTION
- associate each input and textarea with a <label> via htmlFor/id
- derive label text from field.label or field.placeholder
- placeholders remain for visual hint, labels ensure screen reader support